### PR TITLE
fix(ui): show empty state text in property and AI prompt menus

### DIFF
--- a/core/extensions/ai/components/AiWritingPanel.tsx
+++ b/core/extensions/ai/components/AiWritingPanel.tsx
@@ -64,6 +64,11 @@ const PromptList = ({ onClick }: PromptListProps) => {
 					{list.length > 0 && <CommandInput placeholder={t("ai.search-prompts")} />}
 					<CommandList>
 						<CommandEmpty>{t("ai.no-prompts")}</CommandEmpty>
+						{list.length === 0 && (
+							<div className="py-4 text-center text-muted-foreground text-sm">
+								{t("ai.no-prompts")}
+							</div>
+						)}
 						{list.map((prompt, idx) => (
 							<CommandItem
 								key={prompt.id}

--- a/core/extensions/markdown/core/edit/components/Menu/Groups/Property.tsx
+++ b/core/extensions/markdown/core/edit/components/Menu/Groups/Property.tsx
@@ -108,6 +108,11 @@ const Button = (props: ButtonProps) => {
 							{properties.length > 0 && <CommandInput placeholder={t("properties.find")} />}
 							<CommandList>
 								<CommandEmpty>{t("properties.no-properties")}</CommandEmpty>
+								{properties.length === 0 && (
+									<div className="py-4 text-center text-muted-foreground text-sm">
+										{t("properties.no-properties")}
+									</div>
+								)}
 								<CommandGroup className="overflow-y-auto text-xs" style={{ maxHeight: "11rem" }}>
 									{properties.map((item) => (
 										<CommandItem


### PR DESCRIPTION
Hi there! 👋

I noticed that when opening the property and AI prompt selection menus with no available values, the popover shows an empty blank area instead of letting the user know what's going on (reported in #660).

This PR adds explicit empty state messages to both menus so users get clear feedback when there are no properties or prompts to select:

- **Property menu** (`Property.tsx`): shows "No properties" when the catalog has no custom properties defined.
- **AI prompt menu** (`AiWritingPanel.tsx`): shows "No prompts found" when the prompt list is empty.

The styling uses the same `text-muted-foreground` treatment already used in other empty states across the app (e.g. the user filter in the metrics panel), so it should feel consistent.

I kept the existing `<CommandEmpty>` components in place since they still handle the "search returned no results" case when an input *is* present.

Let me know if you'd like any adjustments — happy to iterate! 😊
