### PR TITLE
feat(gramax-cli): add --single-catalog build mode for root-deployment sites

### DIFF
--- a/apps/gramax-cli/src/Components/hydrate.tsx
+++ b/apps/gramax-cli/src/Components/hydrate.tsx
@@ -70,7 +70,68 @@ const promisedApp: Promise<Application> = (async () => {
 	return app;
 })();
 
+const extractInitialDataFromHtml = (html: string): InitialData => {
+	const marker = "window.__INITIAL_DATA__";
+	const markerIdx = html.indexOf(marker);
+	if (markerIdx === -1) throw new Error("__INITIAL_DATA__ marker not found in fetched HTML");
+	const startIdx = html.indexOf("{", markerIdx);
+	if (startIdx === -1) throw new Error("Initial data JSON start not found");
+
+	let depth = 0;
+	let inString = false;
+	let escape = false;
+	let endIdx = -1;
+	for (let i = startIdx; i < html.length; i++) {
+		const c = html[i];
+		if (escape) {
+			escape = false;
+			continue;
+		}
+		if (c === "\\") {
+			escape = true;
+			continue;
+		}
+		if (c === '"') {
+			inString = !inString;
+			continue;
+		}
+		if (inString) continue;
+		if (c === "{") depth++;
+		else if (c === "}") {
+			depth--;
+			if (depth === 0) {
+				endIdx = i;
+				break;
+			}
+		}
+	}
+	if (endIdx === -1) throw new Error("Initial data JSON end not found");
+	return JSON.parse(html.substring(startIdx, endIdx + 1));
+};
+
+const fetchInitialDataForRoute = async (route: string): Promise<InitialData> => {
+	const trimmed = route.replace(/^\/+/, "").replace(/\/+$/, "");
+	const target = trimmed ? `${trimmed}/` : "./";
+	const url = new URL(target, document.baseURI).href;
+	const response = await fetch(url, { credentials: "same-origin" });
+	if (!response.ok) throw new Error(`Failed to fetch ${url}: ${response.status}`);
+	return extractInitialDataFromHtml(await response.text());
+};
+
 const getData = async (route: string, query: Query) => {
+	if (isSingleCatalogMode()) {
+		const fetched = await fetchInitialDataForRoute(route);
+		return {
+			page: "article" as const,
+			data: {
+				...fetched.data.articlePageData,
+				catalogProps: fetched.data.catalogProps,
+				openGraphData: null,
+			},
+			context: fetched.context,
+		};
+	}
+
 	const app = await promisedApp;
 	const commands = getCommands(app);
 	const language = RouterPathProvider.parsePath(route).language;
@@ -117,7 +178,8 @@ const Component = () => {
 				return;
 			}
 			const cleanPath = removeBasePath(path);
-			if (!cleanPath || cleanPath === "/" || !initialData.context.isArticle) return window.location.reload();
+			if (!initialData.context.isArticle) return window.location.reload();
+			if ((!cleanPath || cleanPath === "/") && !isSingleCatalogMode()) return window.location.reload();
 
 			const data = await getData(cleanPath, parserQuery(query));
 			setData({ path, ...data });

--- a/apps/gramax-cli/src/Components/hydrate.tsx
+++ b/apps/gramax-cli/src/Components/hydrate.tsx
@@ -21,7 +21,7 @@ import Gramax, { type GramaxData } from "../../../browser/src/Gramax";
 import useLocation from "../../../browser/src/logic/Api/useLocation";
 import { type ExtendedWindow, InitialDataKeys } from "../../src/logic/initialDataUtils/types";
 import type { InitialData } from "../logic/ArticleTypes";
-import { getCatalogNameFromInitialData } from "../logic/initialDataUtils/getCatalogName";
+import { getCatalogNameFromInitialData, isSingleCatalogMode } from "../logic/initialDataUtils/getCatalogName";
 
 import "../../../../core/styles/main.css";
 import "../../../../core/styles/chain-icon.css";
@@ -54,7 +54,7 @@ global.config = (window as ExtendedWindow)[InitialDataKeys.CONFIG];
 setFeatureList();
 (global.config as AppConfig).paths = {
 	base: getBasePath(),
-	data: new Path(`/${catalogName}`),
+	data: isSingleCatalogMode() ? new Path("/") : new Path(`/${catalogName}`),
 	default: new Path("/"),
 	root: new Path("/"),
 };

--- a/apps/gramax-cli/src/logic/ArticleDataService.ts
+++ b/apps/gramax-cli/src/logic/ArticleDataService.ts
@@ -13,7 +13,7 @@ import { resolveRootCategory } from "@ext/localization/core/catalogExt";
 import type { RenderableTreeNode } from "@ext/markdown/core/render/logic/Markdoc";
 import assert from "assert";
 import type { ExtendedArticlePageData, InitialArticleData } from "./ArticleTypes";
-import { getItemLinks, replacePathIfNeeded } from "./NavigationUtils";
+import { getItemLinks, replacePathIfNeeded, stripCatalogPrefix } from "./NavigationUtils";
 
 export type StaticArticlePageData = {
 	mode: "read";
@@ -24,6 +24,7 @@ export type StaticArticlePageData = {
 export interface Options {
 	pdfTemplates?: string[];
 	wordTemplates?: string[];
+	singleCatalog?: boolean;
 }
 
 export class ArticleDataService {
@@ -31,6 +32,34 @@ export class ArticleDataService {
 		private readonly _app: Application,
 		private readonly _options: Options,
 	) {}
+
+	private get _singleCatalog(): boolean {
+		return !!this._options.singleCatalog;
+	}
+
+	private _stripCatalogPathsFromArticleProps(articleProps: ClientArticleProps, catalogName: string) {
+		if (!this._singleCatalog) return;
+		if (articleProps.logicPath) articleProps.logicPath = stripCatalogPrefix(articleProps.logicPath, catalogName);
+		if (articleProps.pathname) articleProps.pathname = stripCatalogPrefix(articleProps.pathname, catalogName);
+		if (articleProps.ref?.path) articleProps.ref.path = stripCatalogPrefix(articleProps.ref.path, catalogName);
+	}
+
+	private _stripCatalogFromRenderTree(node: unknown, catalogName: string): void {
+		if (!node || typeof node !== "object") return;
+		if (Array.isArray(node)) {
+			for (const child of node) this._stripCatalogFromRenderTree(child, catalogName);
+			return;
+		}
+		const n = node as { attributes?: Record<string, unknown>; children?: unknown };
+		const attrs = n.attributes;
+		if (attrs) {
+			for (const key of ["href", "renderSrc", "resourcePath"]) {
+				const val = attrs[key];
+				if (typeof val === "string") attrs[key] = stripCatalogPrefix(val, catalogName);
+			}
+		}
+		if (n.children) this._stripCatalogFromRenderTree(n.children, catalogName);
+	}
 
 	async getArticlesPageData(
 		context: Context,
@@ -41,15 +70,19 @@ export class ArticleDataService {
 		const sitePresenter = this._app.sitePresenterFactory.fromContext(context);
 		const articlesPageData: ExtendedArticlePageData[] = [];
 
+		const effectiveDefaultLogicPath = this._singleCatalog
+			? stripCatalogPrefix(defaultArticleLogicPath, catalog.name)
+			: defaultArticleLogicPath;
+
 		const getArticle404InitialData = async () => {
-			const itemLinks = await getItemLinks(catalog, "", sitePresenter);
+			const itemLinks = await getItemLinks(catalog, "", sitePresenter, this._singleCatalog);
 
 			const article404 = this._app.customArticlePresenter.getArticle("Article404", {});
 			const article404PageData = {
 				...(await this._getStaticArticlePageData(article404, catalog, context)),
 				itemLinks,
 			};
-			article404PageData.articleProps.logicPath = defaultArticleLogicPath;
+			article404PageData.articleProps.logicPath = effectiveDefaultLogicPath;
 			articlesPageData.push(article404PageData);
 		};
 
@@ -76,7 +109,7 @@ export class ArticleDataService {
 			sitePresenter,
 			context,
 		);
-		defaultArticlePageData.articleProps.logicPath = defaultArticleLogicPath;
+		defaultArticlePageData.articleProps.logicPath = effectiveDefaultLogicPath;
 		articlesPageData.push(defaultArticlePageData);
 
 		for (const item of nav) {
@@ -115,7 +148,7 @@ export class ArticleDataService {
 		context: Context,
 		logicPath: string,
 	): Promise<ExtendedArticlePageData> {
-		const itemLinks = await getItemLinks(catalog, "", sitePresenter);
+		const itemLinks = await getItemLinks(catalog, "", sitePresenter, this._singleCatalog);
 
 		const article404 = this._app.customArticlePresenter.getArticle("Article404", { logicPath });
 
@@ -128,6 +161,9 @@ export class ArticleDataService {
 	private async _getCatalogProps(sitePresenter: SitePresenter, catalog: Catalog) {
 		const props = await this._getAnonymizedCatalogProps(sitePresenter, catalog);
 		props.link.pathname = RouterPathProvider.getLogicPath(props.link.pathname);
+		if (this._singleCatalog && props.link.pathname) {
+			props.link.pathname = stripCatalogPrefix(props.link.pathname, catalog.name);
+		}
 		return props;
 	}
 
@@ -161,7 +197,7 @@ export class ArticleDataService {
 		sitePresenter: SitePresenter,
 		context: Context,
 	): Promise<ExtendedArticlePageData> {
-		const itemLinks = await getItemLinks(catalog, article.ref.path.value, sitePresenter);
+		const itemLinks = await getItemLinks(catalog, article.ref.path.value, sitePresenter, this._singleCatalog);
 
 		return {
 			...(await this._getStaticArticlePageData(article, catalog, context)),
@@ -180,9 +216,12 @@ export class ArticleDataService {
 		await parseContent(article, catalog, context, this._app.parser, this._app.parserContextFactory);
 		const articleProps = await sp.serializeArticleProps(article, await catalog.getPathname(article));
 		articleProps.ref.path = replacePathIfNeeded(articleProps.ref.path, catalog);
+		this._stripCatalogPathsFromArticleProps(articleProps, catalog.name);
+		const content = await article.parsedContent.read((p) => p.renderTree);
+		if (this._singleCatalog) this._stripCatalogFromRenderTree(content, catalog.name);
 		return {
 			mode: "read",
-			content: await article.parsedContent.read((p) => p.renderTree),
+			content,
 			articleProps,
 		};
 	}

--- a/apps/gramax-cli/src/logic/NavigationUtils.ts
+++ b/apps/gramax-cli/src/logic/NavigationUtils.ts
@@ -7,18 +7,35 @@ export const getItemLinks = async (
 	catalog: ReadonlyCatalog,
 	currentItemLogicPath: string,
 	sitePresenter: SitePresenter,
+	singleCatalog = false,
 ) => {
 	const itemLinks = await sitePresenter.getCatalogNav(catalog, currentItemLogicPath);
-	updatePathnames(catalog, itemLinks);
+	updatePathnames(catalog, itemLinks, singleCatalog);
 	return itemLinks;
 };
 
-const updatePathnames = (catalog: ReadonlyCatalog, itemLinks: ItemLink[]) => {
+export const stripCatalogPrefix = (path: string, catalogName: string): string => {
+	if (!path || !catalogName) return path;
+	const hasLeadingSlash = path.startsWith("/");
+	const normalized = hasLeadingSlash ? path.substring(1) : path;
+	if (normalized === catalogName) return "";
+	if (normalized.startsWith(`${catalogName}/`)) return normalized.substring(catalogName.length + 1);
+	return path;
+};
+
+const updatePathnames = (catalog: ReadonlyCatalog, itemLinks: ItemLink[], singleCatalog: boolean) => {
+	const catalogName = catalog.name;
+
 	const processItems = (items: ItemLink[]) =>
 		items.forEach((itemLink) => {
 			itemLink.ref.storageId = "";
 			itemLink.ref.path = replacePathIfNeeded(itemLink.ref.path, catalog);
 			itemLink.pathname = RouterPathProvider.getLogicPath(itemLink.pathname);
+
+			if (singleCatalog) {
+				itemLink.pathname = stripCatalogPrefix(itemLink.pathname, catalogName);
+				itemLink.ref.path = stripCatalogPrefix(itemLink.ref.path, catalogName);
+			}
 
 			if ((itemLink as CategoryLink).items) {
 				processItems((itemLink as CategoryLink).items);
@@ -31,5 +48,9 @@ const updatePathnames = (catalog: ReadonlyCatalog, itemLinks: ItemLink[]) => {
 export const replacePathIfNeeded = (path: string, catalog: ReadonlyCatalog): string => {
 	const catalogFolderPath = catalog.getRootCategory().folderPath.value;
 	const catalogBasePath = catalog.basePath.value;
-	return path.replace(catalogFolderPath, catalogBasePath);
+	const replaced = path.replace(catalogFolderPath, catalogBasePath);
+	if (typeof process !== "undefined" && process.env?.GRAMAX_SINGLE_CATALOG === "true") {
+		return stripCatalogPrefix(replaced, catalog.name);
+	}
+	return replaced;
 };

--- a/apps/gramax-cli/src/logic/StaticContentCopier.ts
+++ b/apps/gramax-cli/src/logic/StaticContentCopier.ts
@@ -45,9 +45,10 @@ class StaticContentCopier {
 	private _wfp: MountFileProvider;
 	private _catalog!: Catalog;
 	private _targetDir!: Path;
+	private _pathPrefix!: string;
 
-	async copyCatalog(catalog: Catalog, targetDir: Path) {
-		this._initializeContext(catalog, targetDir);
+	async copyCatalog(catalog: Catalog, targetDir: Path, singleCatalog = false) {
+		this._initializeContext(catalog, targetDir, singleCatalog);
 		const catalogItems = await this._parseAndValidateCatalogItems();
 
 		await this._copyRootDirectoryAndLogos();
@@ -72,12 +73,13 @@ class StaticContentCopier {
 		};
 	}
 
-	private _initializeContext(catalog: Catalog, targetDir: Path) {
+	private _initializeContext(catalog: Catalog, targetDir: Path, singleCatalog: boolean) {
 		this._initialized = true;
 		this._wmPath = this._app.wm.current().path();
 		this._directoryTree = { type: "dir", name: "docs", children: [] };
 		this._catalog = catalog;
 		this._targetDir = targetDir;
+		this._pathPrefix = singleCatalog ? "" : catalog.name;
 		this._helpers = this._createDirectoryHelpers();
 		this._folderPath = this._catalog.getRootCategory().folderPath.value;
 		this._wfp = this._app.wm.current().getFileProvider();
@@ -85,7 +87,8 @@ class StaticContentCopier {
 
 	private _createDirectoryHelpers(): DirectoryHelpers {
 		const addToDirectoryTree = (path: string) => {
-			const parts = path.split("/");
+			const parts = path.split("/").filter(Boolean);
+			if (!parts.length) return;
 			let currentDir = this._directoryTree;
 			for (let i = 0; i < parts.length - 1; i++) {
 				let nextDir = currentDir.children.find(
@@ -113,9 +116,10 @@ class StaticContentCopier {
 
 		const copyLogoFile = async (logoProp: string, catalog: Catalog) => {
 			if (!catalog.props[logoProp]) return;
+			const logPath = new Path(catalog.props[logoProp]);
 			await copyFileFromWorkspace(
-				catalog.getRootCategoryDirectoryPath().join(new Path(catalog.props[logoProp])),
-				new Path(catalog.name).join(new Path(catalog.props[logoProp])),
+				catalog.getRootCategoryDirectoryPath().join(logPath),
+				this._prefixPath(logPath),
 			);
 		};
 
@@ -136,12 +140,18 @@ class StaticContentCopier {
 		return items;
 	}
 
+	private _prefixPath(relativePath: Path): Path {
+		const stripped = relativePath.value.replace(/^\/+/, "");
+		const cleanPath = new Path(stripped);
+		return this._pathPrefix ? new Path(this._pathPrefix).join(cleanPath) : cleanPath;
+	}
+
 	private async _copyRootDirectoryAndLogos() {
 		const docroot = this._catalog.getRootCategoryRef().path;
 		if (await this._wfp.exists(docroot)) {
 			await this._helpers.copyFileFromWorkspace(
 				docroot,
-				new Path(this._catalog.name).join(new Path(docroot.value.replace(this._folderPath, ""))),
+				this._prefixPath(new Path(docroot.value.replace(this._folderPath, ""))),
 			);
 			await this._helpers.copyLogoFile("logo", this._catalog);
 			await this._helpers.copyLogoFile("logo_dark", this._catalog);
@@ -155,9 +165,7 @@ class StaticContentCopier {
 
 		for (const item of items) {
 			const itemPath = item.ref.path;
-			const targetArticlePath = new Path(this._catalog.name).join(
-				new Path(itemPath.value.replace(this._folderPath, "")),
-			);
+			const targetArticlePath = this._prefixPath(new Path(itemPath.value.replace(this._folderPath, "")));
 			await this._helpers.copyFileFromWorkspace(itemPath, targetArticlePath, zipFileProvider);
 		}
 
@@ -175,7 +183,12 @@ class StaticContentCopier {
 		const zipHash = crypto.MD5(buffer.toString("hex")).toString().substring(0, 8);
 		const zipFilename = `${zipHash}.zip`;
 
-		await this._fp.write(this._targetDir.join(new Path([this._catalog.name, zipFilename])), buffer);
+		await this._fp.write(
+			this._pathPrefix
+				? this._targetDir.join(new Path([this._pathPrefix, zipFilename]))
+				: this._targetDir.join(new Path(zipFilename)),
+			buffer,
+		);
 
 		return zipFilename;
 	}
@@ -186,7 +199,7 @@ class StaticContentCopier {
 
 		for (const snippet of sortedSnippets) {
 			const path = snippet.ref.path;
-			const targetPath = new Path(this._catalog.name).join(new Path(path.value.replace(this._folderPath, "")));
+			const targetPath = this._prefixPath(new Path(path.value.replace(this._folderPath, "")));
 			await this._helpers.copyFileFromWorkspace(path, targetPath);
 
 			await this._copyItemResources(snippet);
@@ -198,7 +211,7 @@ class StaticContentCopier {
 		const sortedIconPaths = sortForDeterministicOrder(iconPaths, (path) => path.value);
 
 		for (const path of sortedIconPaths) {
-			const targetPath = new Path(this._catalog.name).join(new Path(path.value.replace(this._folderPath, "")));
+			const targetPath = this._prefixPath(new Path(path.value.replace(this._folderPath, "")));
 			await this._helpers.copyFileFromWorkspace(path, targetPath);
 		}
 	}
@@ -218,9 +231,7 @@ class StaticContentCopier {
 
 		for (const r of sortedResources) {
 			const absolutePath = rm.getAbsolutePath(new Path(decodeURIComponent(r.value)));
-			const targetPath = new Path(this._catalog.name).join(
-				new Path(absolutePath.value.replace(this._folderPath, "")),
-			);
+			const targetPath = this._prefixPath(new Path(absolutePath.value.replace(this._folderPath, "")));
 			await this._helpers.copyFileFromWorkspace(absolutePath, targetPath);
 		}
 	}

--- a/apps/gramax-cli/src/logic/StaticSiteBuilder.ts
+++ b/apps/gramax-cli/src/logic/StaticSiteBuilder.ts
@@ -45,6 +45,7 @@ interface StaticSiteGenerationOptions {
 		copyWordTemplatesFunction?: CopyTemplatesFunction;
 		copyPdfTemplatesFunction?: CopyTemplatesFunction;
 	};
+	singleCatalog?: boolean;
 }
 
 interface StaticSiteBuilderParams {
@@ -66,12 +67,13 @@ class StaticSiteBuilder {
 	}
 
 	async generate(catalog: Catalog, targetDir: Path, options: StaticSiteGenerationOptions) {
-		const { copyTemplate, customStyles, baseUrl } = options;
+		const { copyTemplate, customStyles, baseUrl, singleCatalog = false } = options;
 		const catalogName = catalog.name;
+		const pathPrefix = singleCatalog ? "" : catalogName;
 
 		const directoryCopier = new StaticContentCopier(this._params.fp, this._params.app);
 		const { zipFilename } = await logStepWithErrorSuppression("Copying directory", () =>
-			directoryCopier.copyCatalog(catalog, targetDir),
+			directoryCopier.copyCatalog(catalog, targetDir, singleCatalog),
 		);
 		const { directoryTree, wordTemplates, pdfTemplates } = await directoryCopier.copyWordTemplates(copyTemplate);
 
@@ -79,21 +81,30 @@ class StaticSiteBuilder {
 			"Rendering HTML pages",
 			async () => {
 				return {
-					rendered: await new StaticRenderer(this._params.app, { wordTemplates, pdfTemplates }).render(
-						catalogName,
-					),
-					searchDirectoryTree: await this._createSearchIndexes(catalog, targetDir),
+					rendered: await new StaticRenderer(this._params.app, {
+						wordTemplates,
+						pdfTemplates,
+						singleCatalog,
+					}).render(catalogName),
+					searchDirectoryTree: await this._createSearchIndexes(catalog, targetDir, pathPrefix),
 				};
 			},
 		);
-		const catalogDirectory = directoryTree.children.find((v) => v.name === catalogName) as DirectoryInfoBasic;
-		assert(catalogDirectory, "not found catalog directory in directory tree");
 
-		catalogDirectory.children.push(searchDirectoryTree);
+		if (singleCatalog) {
+			directoryTree.children.push(searchDirectoryTree);
+		} else {
+			const catalogDirectory = directoryTree.children.find((v) => v.name === catalogName) as DirectoryInfoBasic;
+			assert(catalogDirectory, "not found catalog directory in directory tree");
+			catalogDirectory.children.push(searchDirectoryTree);
+		}
 
 		if (customStyles) {
-			await this._params.fp.write(targetDir.join(new Path([catalogName, CUSTOM_STYLE_FILENAME])), customStyles);
-			const customStyleLinkTag = this._createCustomStyleLinkTag(catalogName);
+			const cssPath = pathPrefix
+				? targetDir.join(new Path([pathPrefix, CUSTOM_STYLE_FILENAME]))
+				: targetDir.join(new Path(CUSTOM_STYLE_FILENAME));
+			await this._params.fp.write(cssPath, customStyles);
+			const customStyleLinkTag = this._createCustomStyleLinkTag(pathPrefix);
 			this._params.html = this._params.html.replace(htmlTags.styles, `${customStyleLinkTag}\n${htmlTags.styles}`);
 		}
 
@@ -102,19 +113,23 @@ class StaticSiteBuilder {
 		const dataJsHash = this._generateHash(dataJsContent);
 		const dataJsFilename = `data.${dataJsHash}.js`;
 
-		await this._params.fp.write(targetDir.join(new Path([catalogName, dataJsFilename])), dataJsContent);
+		const dataJsPath = pathPrefix
+			? targetDir.join(new Path([pathPrefix, dataJsFilename]))
+			: targetDir.join(new Path(dataJsFilename));
+		await this._params.fp.write(dataJsPath, dataJsContent);
 
 		await logStep("Writing rendered HTML files", () =>
-			this._writingRenderedHtmlFiles(rendered, targetDir, catalogName, dataJsFilename, zipFilename),
+			this._writingRenderedHtmlFiles(rendered, targetDir, catalogName, dataJsFilename, zipFilename, singleCatalog),
 		);
 
 		if (baseUrl)
 			await logStep("Creating sitemap.xml & robots.txt", () => this._writeSEOFiles(baseUrl, catalog, targetDir));
 	}
 
-	private _createSearchIndexes = async (catalog: Catalog, targetDir: Path) => {
+	private _createSearchIndexes = async (catalog: Catalog, targetDir: Path, pathPrefix?: string) => {
+		const indexDir = pathPrefix ? targetDir.join(new Path(pathPrefix)) : targetDir;
 		const { cacheFileProvider, articleStorageFileProvider } =
-			this._params.getCache.fp?.() ?? createModulithFileProviders(targetDir.join(new Path(catalog.name)));
+			this._params.getCache.fp?.() ?? createModulithFileProviders(indexDir);
 		const client = await resolveBackendModule("getModulithSearchClient")({
 			cacheFileProvider,
 			articleStorageFileProvider,
@@ -141,18 +156,23 @@ class StaticSiteBuilder {
 		catalogName: string,
 		dataJsFilename: string,
 		zipFilename: string,
+		singleCatalog = false,
 	) => {
 		const config = getConfig();
 		config.isProduction = true;
 		config.isReadOnly = true;
 		(config as StaticConfig).features = getRawEnabledFeatures();
 
+		const pathPrefix = singleCatalog ? "" : catalogName;
+		const dataJsSrc = pathPrefix ? `${pathPrefix}/${dataJsFilename}` : dataJsFilename;
+
 		const templateHtml = this._params.html
 			.replace(htmlTags.config, `window.${InitialDataKeys.CONFIG} = ${this._stringifyDataSafely(config) ?? "{}"}`)
 			.replace(
 				htmlTags.fs,
-				`<script src="${catalogName}/${dataJsFilename}"></script>\n` +
-					`<script>window.${InitialDataKeys.ZIP_FILENAME} = "${zipFilename}";</script>`,
+				`<script src="${dataJsSrc}"></script>\n` +
+					`<script>window.${InitialDataKeys.ZIP_FILENAME} = "${zipFilename}";</script>\n` +
+					`<script>window.${InitialDataKeys.SINGLE_CATALOG} = ${singleCatalog ? "true" : "false"};</script>`,
 			);
 
 		const generateHtmlFile = async (htmlData: HtmlData) => {
@@ -163,10 +183,16 @@ class StaticSiteBuilder {
 			const getLogicPath = () => {
 				const get404Path = () => {
 					if (isBrowser) return [htmlData.logicPath, "404.html"];
+					if (singleCatalog) return [htmlData.logicPath, "404.html"];
 					return [htmlData.logicPath.substring(catalogName.length), "404.html"];
 				};
 
 				if (is404Html) return new Path(get404Path());
+				if (singleCatalog) {
+					return htmlData.logicPath
+						? new Path(htmlData.logicPath).join(new Path("index.html"))
+						: new Path("index.html");
+				}
 				return new Path(htmlData.logicPath).join(new Path("index.html"));
 			};
 
@@ -190,7 +216,7 @@ class StaticSiteBuilder {
 			await this._params.fp.write(filePath, html);
 		};
 
-		if (!isBrowser)
+		if (!isBrowser && !singleCatalog)
 			await this._params.fp.write(targetDir.join(new Path("index.html")), this._getRedirectHTML(catalogName));
 
 		for (const htmlData of htmlDatas) await generateHtmlFile(htmlData);
@@ -225,8 +251,9 @@ class StaticSiteBuilder {
 	</html>`;
 	}
 
-	private _createCustomStyleLinkTag(catalogName: string) {
-		return `<link id="${CUSTOM_STYLE_LINK_ID}" rel="stylesheet" crossorigin href="${catalogName}/${CUSTOM_STYLE_FILENAME}">`;
+	private _createCustomStyleLinkTag(pathPrefix: string) {
+		const href = pathPrefix ? `${pathPrefix}/${CUSTOM_STYLE_FILENAME}` : CUSTOM_STYLE_FILENAME;
+		return `<link id="${CUSTOM_STYLE_LINK_ID}" rel="stylesheet" crossorigin href="${href}">`;
 	}
 
 	static buildDirectoryTreeFromPaths(filePaths: string[]): DirectoryInfoBasic {

--- a/apps/gramax-cli/src/logic/cli/build/command.ts
+++ b/apps/gramax-cli/src/logic/cli/build/command.ts
@@ -13,6 +13,7 @@ export interface BuildOptions {
 	docxTemplates: string;
 	pdfTemplates: string;
 	baseUrl: string;
+	singleCatalog: boolean;
 }
 
 export interface OptionProps {
@@ -96,6 +97,13 @@ const buildOptions: { [K in keyof BuildOptions]: OptionProps } = {
 	baseUrl: {
 		description: "Base site URL for sitemap.xml and robots.txt.",
 		type: "url",
+	},
+	singleCatalog: {
+		description: "Build without catalog name prefix in URLs (for single-catalog deployments)",
+		defaultValue: {
+			value: false,
+			description: "false",
+		},
 	},
 };
 

--- a/apps/gramax-cli/src/logic/cli/build/copyTemplatesInCli.ts
+++ b/apps/gramax-cli/src/logic/cli/build/copyTemplatesInCli.ts
@@ -21,6 +21,7 @@ interface GetCopyTemplateOptions {
 	fp: DiskFileProvider;
 	sourcePath?: string;
 	catalogName: string;
+	singleCatalog?: boolean;
 }
 
 interface CopyTemplateOptions extends GetCopyTemplateOptions {
@@ -139,7 +140,7 @@ const getTemplatePaths = async (
 const copyTemplatesInCli =
 	(options: CopyTemplateOptions): CopyTemplatesFunction =>
 	async (copyFile) => {
-		const { fp, templateType, sourcePath, catalogName } = options;
+		const { fp, templateType, sourcePath, catalogName, singleCatalog } = options;
 
 		if (!sourcePath) return [];
 
@@ -148,7 +149,9 @@ const copyTemplatesInCli =
 
 		const templates: string[] = [];
 		const subDir = templateType === "word" ? WORD_SUBDIR : PDF_SUBDIR;
-		const templatesDir = new Path([catalogName, GRAMAX_DIR, ASSETS_DIR, subDir]);
+		const templatesDir = new Path(
+			singleCatalog ? [GRAMAX_DIR, ASSETS_DIR, subDir] : [catalogName, GRAMAX_DIR, ASSETS_DIR, subDir],
+		);
 
 		for (const src of validTemplates) {
 			try {

--- a/apps/gramax-cli/src/logic/cli/build/index.ts
+++ b/apps/gramax-cli/src/logic/cli/build/index.ts
@@ -104,8 +104,10 @@ const validateBaseUrl = (baseUrl: string | undefined): void => {
 	}
 };
 
-const getStorageTree = (catalogName: string, targetDir: Path, fp: DiskFileProvider) => async () => {
-	const baseDirPath = targetDir.join(new Path(catalogName), new Path(STORAGE_DIR_NAME));
+const getStorageTree = (pathPrefix: string, targetDir: Path, fp: DiskFileProvider) => async () => {
+	const baseDirPath = pathPrefix
+		? targetDir.join(new Path(pathPrefix), new Path(STORAGE_DIR_NAME))
+		: targetDir.join(new Path(STORAGE_DIR_NAME));
 	const resDir: DirectoryInfoBasic = {
 		type: "dir",
 		name: STORAGE_DIR_NAME,
@@ -139,7 +141,7 @@ const getStorageTree = (catalogName: string, targetDir: Path, fp: DiskFileProvid
 };
 
 const buildCommandFunction = async (options: BuildOptions) => {
-	const { source, destination, SkipCheck, customCss, docxTemplates, baseUrl, pdfTemplates, ...configOptions } =
+	const { source, destination, SkipCheck, customCss, docxTemplates, baseUrl, pdfTemplates, SingleCatalog, ...configOptions } =
 		options;
 
 	const targetDir = new Path(destination);
@@ -155,6 +157,9 @@ const buildCommandFunction = async (options: BuildOptions) => {
 	const catalogName = basename(fullPath);
 	await setEnv(fullPath, configOptions);
 	setFeatureList();
+
+	if (SingleCatalog) process.env.GRAMAX_SINGLE_CATALOG = "true";
+	else delete process.env.GRAMAX_SINGLE_CATALOG;
 
 	const app = await getApp();
 	const wm = app.wm.current();
@@ -173,17 +178,30 @@ const buildCommandFunction = async (options: BuildOptions) => {
 
 	const customStyles = await loadCustomStyles(customCss, fp);
 
+	const pathPrefix = SingleCatalog ? "" : catalogName;
+
 	const getCache = {
-		tree: getStorageTree(catalogName, targetDir, fp),
+		tree: getStorageTree(pathPrefix, targetDir, fp),
 	};
 
 	await new StaticSiteBuilder({ fp, app, html: templateHtml, getCache }).generate(catalog, targetDir, {
 		customStyles,
 		copyTemplate: {
-			copyWordTemplatesFunction: copyWordTemplatesInCli({ fp, catalogName, sourcePath: docxTemplates }),
-			copyPdfTemplatesFunction: copyPdfTemplatesInCli({ fp, catalogName, sourcePath: pdfTemplates }),
+			copyWordTemplatesFunction: copyWordTemplatesInCli({
+				fp,
+				catalogName,
+				sourcePath: docxTemplates,
+				singleCatalog: SingleCatalog,
+			}),
+			copyPdfTemplatesFunction: copyPdfTemplatesInCli({
+				fp,
+				catalogName,
+				sourcePath: pdfTemplates,
+				singleCatalog: SingleCatalog,
+			}),
 		},
 		baseUrl,
+		singleCatalog: SingleCatalog,
 	});
 };
 

--- a/apps/gramax-cli/src/logic/initialDataUtils/getCatalogName.ts
+++ b/apps/gramax-cli/src/logic/initialDataUtils/getCatalogName.ts
@@ -13,7 +13,13 @@ export const getCatalogNameFromInitialData = (): string => {
 	return data.data.catalogProps.name;
 };
 
+export const isSingleCatalogMode = (): boolean => {
+	if (typeof window === "undefined") return false;
+	return !!(window as ExtendedWindow)[InitialDataKeys.SINGLE_CATALOG];
+};
+
 export const getBaseCatalogName = () => {
+	if (isSingleCatalogMode()) return "";
 	const catalogName = getCatalogNameFromInitialData();
 	return BaseCatalog.parseName(catalogName).name;
 };

--- a/apps/gramax-cli/src/logic/initialDataUtils/types.ts
+++ b/apps/gramax-cli/src/logic/initialDataUtils/types.ts
@@ -14,6 +14,7 @@ export enum InitialDataKeys {
 	CONFIG = "__INITIAL_CONFIG__",
 	DIRECTORY = "__DIRECTORY__",
 	ZIP_FILENAME = "__ZIP_FILENAME__",
+	SINGLE_CATALOG = "__SINGLE_CATALOG__",
 }
 
 export type StaticConfig = AppConfig & {
@@ -25,4 +26,5 @@ export type ExtendedWindow = Window & {
 	[InitialDataKeys.CONFIG]?: StaticConfig;
 	[InitialDataKeys.DIRECTORY]?: DirectoryInfoBasic;
 	[InitialDataKeys.ZIP_FILENAME]?: string;
+	[InitialDataKeys.SINGLE_CATALOG]?: boolean;
 };


### PR DESCRIPTION
## Summary / Суть

New `--single-catalog` flag for `gramax-cli build`. When set, the generated
site is laid out at the destination root instead of under a
`<catalogName>/` subfolder. Natural fit when a single catalog is the entire
site (product docs portal, internal wiki, etc.) and you want pages at `/` and
`/<article>` rather than `/<catalogName>/<article>`. Default is off —
behaviour unchanged.

Новый флаг `--single-catalog` у `gramax-cli build`. С ним контент кладётся
прямо в корень destination, без подпапки `<catalogName>/`. Удобно, когда
каталог один и должен жить на `/` и `/<article>`, а не на
`/<catalogName>/<article>`. По умолчанию выключен — поведение прежнее.

---

## What changes / Что меняется

Split into two commits:

**1. Build output + path stripping**

- Output layout: ZIP, `data.*.js`, `styles.css`, `.storage/`, root
  `index.html`, article folders all land at the destination root. No
  redirect stub.
- `<catalogName>/` prefix is stripped from everything that ends up in
  `initialData`: `articleProps.logicPath/pathname/ref.path`,
  `catalogProps.link.pathname`, `itemLink.pathname/ref.path`,
  and from `Image.renderSrc` / `Link.href` / `Link.resourcePath` inside
  the parsed render tree.
- Client runtime: new `window.__SINGLE_CATALOG__` flag;
  `getBaseCatalogName()` returns `""` so the static ZIP fetcher and
  workspace asset resolver no longer prepend the catalog name;
  `config.paths.data` is set to `/` so search storage resolves correctly.

**2. SPA navigation via prebuilt HTML**

In single-catalog mode the client workspace treats each top-level directory
in the ZIP as a standalone pseudo-catalog (`FileStructure.getCatalogDirs`
scans top-level dirs). Calling `commands.page.getPageData` on a SPA click
would therefore resolve the wrong catalog and return partial nav data.

Instead, SPA navigation fetches the prebuilt HTML for the target route,
extracts `window.__INITIAL_DATA__` with a balanced-brace scan, and hands
it to `setData`. Whole thing is contained in `hydrate.tsx`, no shared code
touched. SSR output is already correct per page — the client just reuses it.

---

## Compatibility / Совместимость

Behaviour without the flag is unchanged. A `process.env.GRAMAX_SINGLE_CATALOG`
is set only during the CLI build so shared helpers like
`replacePathIfNeeded()` can opt into stripping without each caller passing a
flag — not exposed to the client bundle at runtime.