### PR TITLE
featch: Add Docker Compose Setup for Local Gramax Demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Docker image and host binding.
+GRAMAX_IMAGE_TAG=latest
+GRAMAX_PORT=8080
+GRAMAX_CONTENT_PATH=./content
+
+# Change these values before exposing Gramax outside your local machine.
+GRAMAX_ADMIN_LOGIN=admin
+GRAMAX_ADMIN_PASSWORD=change-me
+GRAMAX_COOKIE_SECRET=replace-with-a-random-secret
+GRAMAX_SHARE_ACCESS_TOKEN=replace-with-a-random-token
+

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ private.env
 ehthumbs.db
 Thumbs.db
 .env*
+!.env.example
 junit*.xml
 .idea/
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,34 @@ For more details, see the [official documentation](https://gram.ax/resources/doc
 
 Publish your documentation as a website, hosted on your server or as a static site.
 
-### Setup
+### Run locally with Docker Compose
 
--  **Docker**: Deploy with docker-compose.yaml from [gram.ax/docker-compose.yaml](http://gram.ax/docker-compose.yaml).
+The root `compose.yaml` starts the documentation portal from the published
+`gramax/docportal` image and stores its content in the local `content` directory.
+
+```bash
+cp .env.example .env
+mkdir -p content
+docker compose up -d
+```
+
+Open [http://localhost:8080](http://localhost:8080). Put Gramax catalogs in
+`./content`; each catalog is a directory containing a `.doc-root.yaml` file and
+Markdown articles.
+
+Stop the portal with:
+
+```bash
+docker compose down
+```
+
+The port, content path, image tag, and local credentials can be changed in
+`.env`. Replace the example secrets before exposing the service outside your
+local machine.
+
+### Other setup options
+
+-  **Docker**: Use the root `compose.yaml` or download it from [gram.ax/docker-compose.yaml](http://gram.ax/docker-compose.yaml).
 
 -  **Static Site**:
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,20 @@
+name: gramax
+
+services:
+  docportal:
+    image: gramax/docportal:${GRAMAX_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    ports:
+      - "${GRAMAX_PORT:-8080}:80"
+    environment:
+      PORT: "80"
+      ROOT_PATH: /app/data
+      PRODUCTION: "true"
+      BRANCH: master
+      ADMIN_LOGIN: "${GRAMAX_ADMIN_LOGIN:-admin}"
+      ADMIN_PASSWORD: "${GRAMAX_ADMIN_PASSWORD:-change-me}"
+      COOKIE_SECRET: "${GRAMAX_COOKIE_SECRET:-local-development-secret}"
+      SHARE_ACCESS_TOKEN: "${GRAMAX_SHARE_ACCESS_TOKEN:-local-development-token}"
+    volumes:
+      - "${GRAMAX_CONTENT_PATH:-./content}:/app/data"
+


### PR DESCRIPTION
# Add Docker Compose Setup for Local Gramax Demo

## Summary

Add a simple Docker Compose setup that allows users to run a local Gramax Docportal demo using the published `gramax/docportal` image.

## Demo

```bash
cp .env.example .env
mkdir -p content
docker compose up -d